### PR TITLE
Funcionalidade: enviando o campo "beneficiaryType" na requisição para criação de Invoices

### DIFF
--- a/src/Clients/CaradhrasMainClient.php
+++ b/src/Clients/CaradhrasMainClient.php
@@ -29,7 +29,6 @@ use Throwable;
 
 class CaradhrasMainClient extends BaseApiClient
 {
-
     /**
      * Associate card to account.
      *

--- a/src/Clients/CaradhrasPaymentSlipClient.php
+++ b/src/Clients/CaradhrasPaymentSlipClient.php
@@ -9,6 +9,7 @@ use Idez\Caradhras\Data\InvoicePaymentSlipFine;
 use Idez\Caradhras\Data\InvoicePaymentSlipInterest;
 use Idez\Caradhras\Data\InvoicePaymentSlipPayer;
 use Idez\Caradhras\Data\RechargePaymentSlip;
+use Idez\Caradhras\Enums\PaymentSlip\BeneficiaryType;
 use Idez\Caradhras\Enums\PaymentSlip\PaymentSlipInvoiceType;
 use Idez\Caradhras\Enums\PaymentSlip\PaymentSlipType;
 use Idez\Caradhras\Exceptions\CaradhrasException;
@@ -146,6 +147,7 @@ class CaradhrasPaymentSlipClient extends BaseApiClient
      * @param  null|InvoicePaymentSlipFine  $fine
      * @param  null|InvoicePaymentSlipDiscount  $discount
      * @param  null|InvoicePaymentSlipInterest  $interest
+     * @param  int  $beneficiaryType
      *
      * @return InvoicePaymentSlip
      *
@@ -162,9 +164,14 @@ class CaradhrasPaymentSlipClient extends BaseApiClient
         InvoicePaymentSlipFine $fine = null,
         InvoicePaymentSlipDiscount $discount = null,
         InvoicePaymentSlipInterest $interest = null,
+        int $beneficiaryType = 1,
     ): InvoicePaymentSlip {
         if (! PaymentSlipInvoiceType::tryFrom($invoiceTypeCode)) {
             throw new CaradhrasException('Invalid invoice type code.', 400);
+        }
+
+        if (! BeneficiaryType::tryFrom($beneficiaryType)) {
+            throw new CaradhrasException('Invalid beneficiary type.', 400);
         }
 
         $requestData = [
@@ -193,7 +200,7 @@ class CaradhrasPaymentSlipClient extends BaseApiClient
             $requestData['interest'] = $interest->jsonSerialize();
         }
 
-        $response = $this->apiClient(false)->post('/v1/invoice', $requestData);
+        $response = $this->apiClient(false)->post("/v1/invoice?beneficiaryType={$beneficiaryType}", $requestData);
 
         if ($response->failed()) {
             throw new CreatePaymentSlipException($response);

--- a/src/Enums/PaymentSlip/BeneficiaryType.php
+++ b/src/Enums/PaymentSlip/BeneficiaryType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Idez\Caradhras\Enums\PaymentSlip;
+
+enum BeneficiaryType: int
+{
+    case ProvidedAccount = 1;
+    case IssuerAccount = 2;
+}

--- a/tests/Unit/Clients/CaradhrasPaymentSlipClientTest.php
+++ b/tests/Unit/Clients/CaradhrasPaymentSlipClientTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Idez\Caradhras\Tests\Unit\Clients;
+
+use Carbon\Carbon;
+use Idez\Caradhras\Clients\CaradhrasPaymentSlipClient;
+use Idez\Caradhras\Data\InvoicePaymentSlip;
+use Idez\Caradhras\Data\InvoicePaymentSlipPayer;
+use Idez\Caradhras\Exceptions\CaradhrasException;
+use Idez\Caradhras\Tests\TestCase;
+use Illuminate\Support\Facades\Http;
+
+class CaradhrasPaymentSlipClientTest extends TestCase
+{
+    private CaradhrasPaymentSlipClient $paymentSlipClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->paymentSlipClient = app(CaradhrasPaymentSlipClient::class);
+    }
+
+    public function testCreateInvoiceSuccess(): void
+    {
+        $accountId = 100;
+        $amount = 50.00;
+        $dueDate = Carbon::tomorrow();
+        $invoiceTypeCode = '02';
+        $payer = new InvoicePaymentSlipPayer();
+        $beneficiaryType = 1;
+
+        $expectedRequestUrl = $this->paymentSlipClient->getApiBaseUrl() . "/v1/invoice?beneficiaryType={$beneficiaryType}";
+
+        Http::fake([
+            $expectedRequestUrl => Http::response([
+                'amount' => $amount,
+                'dueDate' => $dueDate,
+            ]),
+        ]);
+
+        $invoicePaymentSlip = $this->paymentSlipClient->createInvoice(
+            accountId: $accountId,
+            amount: $amount,
+            dueDate: $dueDate,
+            invoiceTypeCode: $invoiceTypeCode,
+            payer: $payer,
+            beneficiaryType: $beneficiaryType
+        );
+
+        $this->assertInstanceOf(InvoicePaymentSlip::class, $invoicePaymentSlip);
+    }
+
+    public function testCreateInvoiceWithInvalidBeneficiaryType(): void
+    {
+        $accountId = 100;
+        $amount = 50.00;
+        $dueDate = Carbon::tomorrow();
+        $invoiceTypeCode = '02';
+        $payer = new InvoicePaymentSlipPayer();
+        $beneficiaryType = 3;
+
+        $this->expectException(CaradhrasException::class);
+        $this->expectExceptionMessage('Invalid beneficiary type.');
+        $this->expectExceptionCode(400);
+
+        $this->paymentSlipClient->createInvoice(
+            accountId: $accountId,
+            amount: $amount,
+            dueDate: $dueDate,
+            invoiceTypeCode: $invoiceTypeCode,
+            payer: $payer,
+            beneficiaryType: $beneficiaryType
+        );
+    }
+}


### PR DESCRIPTION
## 🔍 Descrição do PR

O _query param_ `beneficiaryType` informa quem é o beneficiário do pagamento.

## 📝 Mudanças realizadas
- Adicionado o parâmetro `beneficiaryType` que será recebido no método `createInvoice` (padrão é 1).
- O campo `beneficiaryType` passa a ser enviado via queryParam na requisição de criação de Invoice.

## 📄 Doc Caradhras

- https://lighthouse.dock.tech/docs/cards-and-digital-banking-api-reference/0162694664c0a-create-payment-slip-invoice