### PR TITLE
Funcionalidade: para cancelar Alias Banks

### DIFF
--- a/src/Clients/CaradhrasAliasClient.php
+++ b/src/Clients/CaradhrasAliasClient.php
@@ -82,6 +82,17 @@ class CaradhrasAliasClient extends BaseApiClient
         return $response->items;
     }
 
+    public function list(int $accountId): array
+    {
+        $response = $this
+            ->apiClient(false)
+            ->get('/v1/accounts', [
+                'idAccount' => $accountId,
+            ])->object();
+
+        return $response->items;
+    }
+
     /**
      * Delete an alias.
      *

--- a/src/Clients/CaradhrasAliasClient.php
+++ b/src/Clients/CaradhrasAliasClient.php
@@ -82,6 +82,12 @@ class CaradhrasAliasClient extends BaseApiClient
         return $response->items;
     }
 
+    /**
+     * List account aliases.
+     *
+     * @param  int  $accountId
+     * @return array
+     */
     public function list(int $accountId): array
     {
         $response = $this

--- a/src/Clients/CaradhrasAliasClient.php
+++ b/src/Clients/CaradhrasAliasClient.php
@@ -104,15 +104,16 @@ class CaradhrasAliasClient extends BaseApiClient
      *
      * @param  int  $accountId
      * @param  \Idez\Caradhras\Enums\AliasBankProvider $bankProvider
-     * @return Response
+     * @return object
      */
-    public function delete(int $accountId, AliasBankProvider $bankProvider): Response
+    public function delete(int $accountId, AliasBankProvider $bankProvider): object
     {
         return $this
             ->apiClient()
             ->delete('/v1/accounts', [
                 'idAccount' => $accountId,
                 'bankNumber' => $bankProvider->value,
-            ]);
+            ])
+            ->object();
     }
 }

--- a/src/Clients/CaradhrasAliasClient.php
+++ b/src/Clients/CaradhrasAliasClient.php
@@ -91,7 +91,7 @@ class CaradhrasAliasClient extends BaseApiClient
     public function list(int $accountId): array
     {
         $response = $this
-            ->apiClient(false)
+            ->apiClient()
             ->get('/v1/accounts', [
                 'idAccount' => $accountId,
             ])->object();
@@ -109,7 +109,7 @@ class CaradhrasAliasClient extends BaseApiClient
     public function delete(int $accountId, AliasBankProvider $bankProvider): Response
     {
         return $this
-            ->apiClient(false)
+            ->apiClient()
             ->delete('/v1/accounts', [
                 'idAccount' => $accountId,
                 'bankNumber' => $bankProvider->value,

--- a/src/Clients/CaradhrasAliasClient.php
+++ b/src/Clients/CaradhrasAliasClient.php
@@ -81,4 +81,21 @@ class CaradhrasAliasClient extends BaseApiClient
 
         return $response->items;
     }
+
+    /**
+     * Delete an alias.
+     *
+     * @param  int  $accountId
+     * @param  \Idez\Caradhras\Enums\AliasBankProvider $bankProvider
+     * @return Response
+     */
+    public function delete(int $accountId, AliasBankProvider $bankProvider): Response
+    {
+        return $this
+            ->apiClient(false)
+            ->delete('/v1/accounts', [
+                'idAccount' => $accountId,
+                'bankNumber' => $bankProvider->value,
+            ]);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,6 +24,11 @@ class TestCase extends Orchestra
         ];
     }
 
+    protected function arrayToObject(array $data): array|object
+    {
+        return json_decode(json_encode($data));
+    }
+
     public function getEnvironmentSetUp($app)
     {
         config()->set('database.default', 'testing');

--- a/tests/Unit/Clients/CaradhrasAliasClientTest.php
+++ b/tests/Unit/Clients/CaradhrasAliasClientTest.php
@@ -90,7 +90,12 @@ class CaradhrasAliasClientTest extends TestCase
         $expectedRequestUrl = $this->aliasClient->getApiBaseUrl() . '/v1/accounts';
 
         Http::fake([
-            $expectedRequestUrl => Http::response(status: 200),
+            $expectedRequestUrl => Http::response(
+                body: [
+                    'message' => 'This account are closed'
+                ],
+                status: 200,
+            ),
         ]);
 
         $this->aliasClient->delete($accountId, $bankNumber);

--- a/tests/Unit/Clients/CaradhrasAliasClientTest.php
+++ b/tests/Unit/Clients/CaradhrasAliasClientTest.php
@@ -92,7 +92,7 @@ class CaradhrasAliasClientTest extends TestCase
         Http::fake([
             $expectedRequestUrl => Http::response(
                 body: [
-                    'message' => 'This account are closed'
+                    'message' => 'This account are closed',
                 ],
                 status: 200,
             ),

--- a/tests/Unit/Clients/CaradhrasAliasClientTest.php
+++ b/tests/Unit/Clients/CaradhrasAliasClientTest.php
@@ -76,10 +76,9 @@ class CaradhrasAliasClientTest extends TestCase
         $this->assertEquals($result, $this->arrayToObject($expectedItems));
 
         Http::assertSent(
-            function (Request $request) use ($expectedRequestUrl, $accountId) {
-                return $request->url() === $expectedRequestUrl &&
-                    $request['idAccount'] === $accountId;
-            }
+            fn (Request $request) => $request->url() === $expectedRequestUrl
+                && $request->method() === 'GET'
+                && $request['idAccount'] === $accountId
         );
     }
 
@@ -97,11 +96,10 @@ class CaradhrasAliasClientTest extends TestCase
         $this->aliasClient->delete($accountId, $bankNumber);
 
         Http::assertSent(
-            function (Request $request) use ($expectedRequestUrl, $accountId, $bankNumber) {
-                return $request->url() === $expectedRequestUrl &&
-                    $request['idAccount'] === $accountId &&
-                    $request['bankNumber'] === $bankNumber->value;
-            }
+            fn (Request $request) => $request->url() === $expectedRequestUrl
+                && $request->method() === 'DELETE'
+                && $request['idAccount'] === $accountId
+                && $request['bankNumber'] === $bankNumber->value
         );
     }
 }

--- a/tests/Unit/Clients/CaradhrasAliasClientTest.php
+++ b/tests/Unit/Clients/CaradhrasAliasClientTest.php
@@ -44,6 +44,45 @@ class CaradhrasAliasClientTest extends TestCase
         $this->aliasClient->findOrCreate($accountId, AliasBankProvider::Votorantim);
     }
 
+    public function testIfCanListWithSuccess(): void
+    {
+        $accountId = $this->faker->randomNumber(5);
+
+        $expectedRequestUrl = $this->aliasClient->getApiBaseUrl() . "/v1/accounts?idAccount={$accountId}";
+
+        $expectedItems = [
+            [
+                'idAccount' => $accountId,
+                'bankNumber' => '301',
+                'bankAccountStatus' => 'OPEN',
+            ],
+            [
+                'idAccount' => $accountId,
+                'bankNumber' => '208',
+                'bankAccountStatus' => 'CLOSED',
+            ],
+        ];
+
+        $fakeResponse = [
+            'items' => $expectedItems,
+        ];
+
+        Http::fake([
+            $expectedRequestUrl => Http::response(body: $fakeResponse, status: 200),
+        ]);
+
+        $result = $this->aliasClient->list($accountId);
+
+        $this->assertEquals($result, json_decode(json_encode($expectedItems)));
+
+        Http::assertSent(
+            function (Request $request) use ($expectedRequestUrl, $accountId) {
+                return $request->url() === $expectedRequestUrl &&
+                    $request['idAccount'] === $accountId;
+            }
+        );
+    }
+
     public function testIfCanCancelAccountWithSuccess(): void
     {
         $accountId = $this->faker->randomNumber(5);

--- a/tests/Unit/Clients/CaradhrasAliasClientTest.php
+++ b/tests/Unit/Clients/CaradhrasAliasClientTest.php
@@ -73,7 +73,7 @@ class CaradhrasAliasClientTest extends TestCase
 
         $result = $this->aliasClient->list($accountId);
 
-        $this->assertEquals($result, json_decode(json_encode($expectedItems)));
+        $this->assertEquals($result, $this->arrayToObject($expectedItems));
 
         Http::assertSent(
             function (Request $request) use ($expectedRequestUrl, $accountId) {


### PR DESCRIPTION
## :mag: Descrição do PR

Foram adicionados dois métodos:
1. `list`: Para fazer uma listagem dos Alias associados a determinada conta.
2. `delete`: Para cancelar determinado Alias.

A idéia é adicionarmos a possibilidade de listar e cancelarmos aliases através desse SDK.

## 🏷️  Ticket

- https://app.clickup.com/t/8678kz73m

## 📃 Documentação

- [List alias account](https://lighthouse.dock.tech/docs/cards-and-digital-banking-api-reference/ed4f4276b1ede-list-alias-account)
- [Delete alias account](https://lighthouse.dock.tech/docs/cards-and-digital-banking-api-reference/5fb6422ea6c39-delete-alias-account)