### PR TITLE
Hotfix: nullable return

### DIFF
--- a/src/Clients/CaradhrasCardClient.php
+++ b/src/Clients/CaradhrasCardClient.php
@@ -482,10 +482,11 @@ class CaradhrasCardClient extends BaseApiClient
         return $response->successful();
     }
 
-    public function updateHolderName(int $accountId, int $personId, string $name){
+    public function updateHolderName(int $accountId, int $personId, string $name)
+    {
         $response = $this->apiClient()
             ->patch("/contas/{$accountId}/pessoas/{$personId}/portadores", [
-                'nomeImpresso' => $name
+                'nomeImpresso' => $name,
             ])
             ->throw();
 

--- a/src/Clients/CaradhrasIncomeReportsClient.php
+++ b/src/Clients/CaradhrasIncomeReportsClient.php
@@ -17,7 +17,7 @@ class CaradhrasIncomeReportsClient extends BaseApiClient
      * @return object
      * @throws \Idez\Caradhras\Exceptions\FindIncomeReportsException
      */
-    public function getAvailable(int $accountId): object
+    public function getAvailable(int $accountId): ?object
     {
         $request = $this->apiClient(false)
             ->get("/v1/reports/{$accountId}");


### PR DESCRIPTION
A rota `/v1/reports/{account}` da API _declarables_ pode retornar um 204, que quando tenta transformar em objeto retorna _null_

![image](https://github.com/idezdigital/laravel-caradhras-sdk/assets/65680775/828968e3-2350-456b-acf5-bfb6f64953ba)
