### PR TITLE
Corrige a tratativa de envio de CNH digital em contas PJ

### DIFF
--- a/src/Clients/CaradhrasCompanyClient.php
+++ b/src/Clients/CaradhrasCompanyClient.php
@@ -21,6 +21,7 @@ use Idez\Caradhras\Exceptions\UpdateCompanyRegistrationException;
 class CaradhrasCompanyClient extends BaseApiClient
 {
     public const API_PREFIX = 'companies';
+
     public const API_DOCUMENTS_PREFIX = 'docspy-api';
 
     /**
@@ -265,14 +266,14 @@ class CaradhrasCompanyClient extends BaseApiClient
             'category' => $documentType,
         ]);
 
-        $body = [
-            'imageBase64' => $base64,
-            'jwt' => $jwt,
-        ];
-
-        if ($documentType === 'SELFIE' && filled($jwt)) {
-            unset($body['imageBase64']);
-        }
+        $body = match ($documentType) {
+            'SELFIE' => ['jwt' => $jwt],
+            'DIGITAL_DRIVER_LICENSE' => ['imageBase64' => $base64],
+            default => [
+                'imageBase64' => $base64,
+                'jwt' => $jwt,
+            ],
+        };
 
         $response = $this->apiClient(false)
             ->post("/v1/registrations/{$registrationId}/documents/biometric?" . $queryParams, $body);


### PR DESCRIPTION
## Ajustes

- [x] Corrige a tratativa de envio de CNH digital em contas PJ

## Ticket Clickup

https://app.clickup.com/t/9002159733/CX-2318


## Contexto

Segundo a Dock, ao enviar a CNH Digital não podemos passar o campo `jwt`, mesmo que _null_.