### PR TITLE
Correção (Payment): Para jogar exceptions HTTP quando falhar em criar pagamentos

### DIFF
--- a/src/Clients/CaradhrasPaymentClient.php
+++ b/src/Clients/CaradhrasPaymentClient.php
@@ -105,7 +105,7 @@ class CaradhrasPaymentClient extends BaseApiClient
         float $amount,
         string $description
     ): object {
-        $response = $this->apiClient(false)
+        $response = $this->apiClient()
             ->asJson()
             ->retry(5, 2000, fn (Exception $exception, PendingRequest $request) => in_array($exception->getCode(), [424, 422, 409]), false)
             ->post('/v1', [


### PR DESCRIPTION
## Descrição

Ajuste para termos exception em casos de erro de requisição para o endpoint `/v1` de `payments`.